### PR TITLE
Add experiment results for Transformer layers

### DIFF
--- a/caduceus/tests/test_rcps_v2.py
+++ b/caduceus/tests/test_rcps_v2.py
@@ -1,0 +1,137 @@
+from typing import Literal
+import inspect
+import pytest
+import torch
+from torch import nn
+from transformers.models.bert.modeling_bert import BertLayer
+from transformers.models.bert.configuration_bert import BertConfig
+from caduceus.configuration_caduceus import CaduceusConfig
+from caduceus.modeling_caduceus import create_block
+from caduceus.tokenization_caduceus import CaduceusTokenizer
+from mamba_ssm.modules.mamba_simple import Mamba
+
+
+
+def rc(x: torch.Tensor) -> torch.Tensor:
+    if x.has_names:
+        return torch.flip(x.rename(None), dims=[-2, -1]).rename(*x.names)
+    else:
+        return torch.flip(x, dims=[-2, -1])
+    
+class LambdaModule(nn.Module):
+    def __init__(self, module, fn):
+        super().__init__()
+        self.module = module
+        self.fn = fn
+    def forward(self, *args, **kwargs):
+        return self.fn(self.module(*args, **kwargs))
+
+def mamba_layer(config: CaduceusConfig) -> nn.Module:
+    return Mamba(d_model=config.d_model)
+
+def bert_layer(config: CaduceusConfig) -> nn.Module:
+    layer = BertLayer(BertConfig(
+        hidden_size=config.d_model, 
+        vocab_size=config.vocab_size,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        hidden_dropout_prob=0,
+        attention_probs_dropout_prob=0,
+        is_decoder=False
+    ))
+    return LambdaModule(
+        module=layer,
+        fn=lambda x: x[0]
+    )
+
+class CaduceusBlockV2(nn.Module):
+
+    def __init__(self, config: CaduceusConfig, layer: nn.Module):
+        super().__init__()
+        self.config = config
+        self.layer = layer
+        self.norm = nn.LayerNorm(config.d_model)
+    
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.rename("batch", "sequence", "channel")
+        # Double the batch with RC sequences
+        o = torch.cat([x, rc(x)], dim="batch").rename(None)
+        # Process forward and reverse sequences independently
+        o = self.layer(self.norm(o))
+        # Break complementary sequence pairs back out
+        o = o.view(2, *tuple(x.shape)).rename("complement", *x.names)
+        # Sum results for each pair (forward + RC)
+        o = o.sum(dim="complement")
+        assert o.shape == x.shape
+        return o
+
+
+def get_config(n_layer: int):
+    tokenizer = CaduceusTokenizer(model_max_length=5)
+    return CaduceusConfig(
+        d_model=4,
+        n_layer=n_layer,
+        rcps=True,
+        pad_token_id=-100,
+        fused_add_norm=False,
+        rms_norm=False,
+        bidirectional=False,
+        vocab_size=tokenizer.vocab_size,
+        complement_map=tokenizer.complement_map,
+        model_max_length=tokenizer.model_max_length
+    )
+
+@pytest.fixture
+def device():
+    return "cuda"   
+
+def get_caduceus_v1(config: CaduceusConfig, device: str) -> nn.Module:
+    blocks = []
+    for _ in range(config.n_layer):
+        block = create_block(**{
+            k: v for k, v in vars(config).items() 
+            if k in inspect.signature(create_block).parameters
+        }, device=device)
+        original_forward = block.forward
+        block.forward = lambda *args, **kwargs: original_forward(*args, **kwargs)[0]
+        blocks.append(block)
+    return nn.Sequential(*blocks)
+
+def get_caduceus_v2(config: CaduceusConfig, layers: Literal["bert", "mamba"] | list[nn.Module], device: str) -> nn.Module:
+    blocks = []
+    for i in range(config.n_layer):
+        if layers == "bert":
+            layer = bert_layer(config)
+        elif layers == "mamba":
+            layer = mamba_layer(config)
+        else: 
+            layer = layers[i]
+        blocks.append(CaduceusBlockV2(config, layer))
+    return nn.Sequential(*blocks).to(device)
+
+@pytest.mark.parametrize("n_batch", [4])
+def test_v1_v2_equivalence(device, n_batch):
+    config = get_config(n_layer=1)
+    seq = torch.randn(n_batch, config.model_max_length, config.d_model).to(device)
+    caduceus_v1 = get_caduceus_v1(config, device)
+    caduceus_v2 = get_caduceus_v2(config, layers=[
+        list(caduceus_v1)[i].mixer.submodule.mamba_fwd
+        for i in range(config.n_layer)
+    ], device=device)
+
+    # Double the sequence on the channels dimension without RC'ing the second half
+    # because this is how the inputs would be provided from `RCPSEmbedding`; see:
+    # https://github.com/kuleshov-group/caduceus/blob/49e3204dfba5bd36b9c6405bca6b0396e04ab9d2/caduceus/modeling_rcps.py#L65-L67
+    expected = caduceus_v1(torch.cat([seq, seq], dim=-1))
+    expected = expected[..., :config.d_model] + rc(expected[..., config.d_model:])
+    actual = caduceus_v2(seq).rename(None)
+    assert torch.allclose(expected, actual)
+
+@pytest.mark.parametrize("n_batch", [1, 4, 8])
+@pytest.mark.parametrize("n_layer", [1, 5])
+@pytest.mark.parametrize("layer_type", ["bert", "mamba"])
+def test_v2_rc_invariance(device, n_batch, n_layer, layer_type):
+    config = get_config(n_layer=n_layer)
+    seq = torch.randn(n_batch, config.model_max_length, config.d_model).to(device)
+    caduceus_v2 = get_caduceus_v2(config, layers=layer_type, device=device)
+    assert torch.equal(caduceus_v2(seq), caduceus_v2(rc(seq)))


### PR DESCRIPTION
This is a pass at pushing the RCPS logic into the batch dimension rather than managing it with semi-spaces in the channels dimension.  I wanted to try that because it would enable the use of lots of standard Module types and HF models (e.g. I'm using [BertLayer](https://github.com/huggingface/transformers/blob/99e0ab6ed888136ea4877c6d8ab03690a1478363/src/transformers/models/bert/modeling_bert.py#L558) and Mamba in this PR) without needing to wrap or subclass them.  This captures the essence of what I mean: 

https://github.com/eric-czech/caduceus/blob/2f89eb4ca027afa4cc685acfec20ef09431d8964/caduceus/tests/test_rcps_v2.py#L48-L67

That doesn't keep the forward and RC information separate between layers like Caduceus currently does, but it probably could if you did `torch.cat([x, rc(x)], dim="batch")` in the beginning at the `CaduceusMixerModel` level, called some stack of vanilla layer implementations with it (i.e. without wrappers), and then did the `o.view(2, *tuple(x.shape)).rename("complement", *x.names)` stuff at the end.  That would give you a tensor for the sequence and its RC to sum, multiply, concatenate, or whatever else.

Anyways, the code here is just a unit test where:

- This [test_v1_v2_equivalence](https://github.com/eric-czech/caduceus/blob/2f89eb4ca027afa4cc685acfec20ef09431d8964/caduceus/tests/test_rcps_v2.py#L114) test asserts that results from the current Caduceus block type (i.e. `RCPSMambaBlock`) produce equivalent results to blocks defined by that `CaduceusBlockV2` class above.
- The [test_v2_rc_invariance](https://github.com/eric-czech/caduceus/blob/2f89eb4ca027afa4cc685acfec20ef09431d8964/caduceus/tests/test_rcps_v2.py#L140C5-L140C26) test asserts that stacks of `CaduceusBlockV2` blocks are RC-invariant when using both Mamba and BERT layers
  - I'm assuming RC-equivariance is easy to get if you have invariance (i.e. the same results for a sequence and its RC)

Lastly, I'll add that this is ignoring residual connections and I'm not saying it actually makes sense to use BERT layers like this because, for one thing, the `LayerNorm`'s are redundant with the norms applied in `CaduceusBlockV2`.  I tried this with several other layer specifications though like `MultiheadAttention`, MLPs, RNNs, etc. and they all work.  

It's harder to think of reasons it shouldn't work since all that is required is that the order in which a sequence and it's RC appear in a batch is irrelevant.  Dropout is the only reason for that I've run into so far.  Diffusion sampling may be another, or anything else that can be stochastic.

<details><summary>Strach</summary>

Keeping sequence and RC information separate on a per-layer basis could also look something like this:

```python
def forward(self, x: torch.Tensor) -> torch.Tensor:
    assert x.ndim == 4
    assert x.shape[0] == 2
    x = x.rename("complement", "batch", "sequence", "channel")
    o = x.flatten(["complement", "batch"], "batch")
    o = self.layer(self.norm(o.rename(None))).rename(*o.names)
    o = o.unflatten("batch", [('complement', 2), ('batch', o.shape[0]//2)])
    return o
```

</details>
