### PR TITLE
Refactor configs for Mamba2 and hybrid architectures

### DIFF
--- a/caduceus/configuration_caduceus.py
+++ b/caduceus/configuration_caduceus.py
@@ -2,54 +2,156 @@
 
 """
 
-from typing import Optional, Union
+from typing import Literal, Optional, Union, TypeVar, Dict, Any
 
 from transformers import PretrainedConfig
 
 
+T = TypeVar('T', bound=PretrainedConfig)
+ConfigType = Union[Dict[str, Any], T]
+
+
+class CaduceusMambaConfig(PretrainedConfig):
+    """Configuration for Mamba SSM layers.
+
+    For example `ssm_cfg` options, see:
+      - v1: [mamba_ssm/modules/mamba_simple.py#L31-L50](https://github.com/state-spaces/mamba/blob/9182c93c9acb3e4ccac55a18a52c228d870d60bc/mamba_ssm/modules/mamba_simple.py#L31-L50)
+      - v2: [mamba_ssm/modules/mamba2.py#L37-L66](https://github.com/state-spaces/mamba/blob/9182c93c9acb3e4ccac55a18a52c228d870d60bc/mamba_ssm/modules/mamba2.py#L37-L66)
+    """
+    def __init__(
+        self,
+        version: Literal["v1", "v2"] = "v1",
+        ssm_cfg: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.version = version
+        self.ssm_cfg = ssm_cfg
+
+
+class CaduceusLayerConfig(PretrainedConfig):
+    def __init__(
+        self,
+        mode: Literal["mamba-only"] = "mamba-only",
+        mamba_cfg: Optional[ConfigType[CaduceusMambaConfig]] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.mode = mode
+        self.mamba_cfg = CaduceusMambaConfig(**mamba_cfg) if isinstance(mamba_cfg, dict) else mamba_cfg or CaduceusMambaConfig()
+
+
+class CaduceusNormConfig(PretrainedConfig):
+    def __init__(
+        self,
+        fused_add_norm: bool = True,
+        rms_norm: bool = True,
+        norm_epsilon: float = 1e-5,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.fused_add_norm = fused_add_norm
+        self.rms_norm = rms_norm
+        self.norm_epsilon = norm_epsilon
+
+
+class CaduceusInitializerConfig(PretrainedConfig):
+    def __init__(
+        self,
+        rescale_prenorm_residual: bool = True,
+        initializer_range: float = 0.02,
+        n_residuals_per_layer: int = 1,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.rescale_prenorm_residual = rescale_prenorm_residual
+        self.initializer_range = initializer_range
+        self.n_residuals_per_layer = n_residuals_per_layer
+
+
 class CaduceusConfig(PretrainedConfig):
-    """Config that extends the original MambaConfig with params relevant to bi-directionality and RC equivariance."""
+    """Configuration class for Caduceus model.
+
+    Args:
+        # Model Architecture
+        d_model: Hidden dimension of the model (default: 2560)
+        n_layer: Number of layers in the model (default: 64)
+        vocab_size: Size of the vocabulary (default: 50277)
+        pad_vocab_size_multiple: Pad vocabulary size to be divisible by this value (default: 8)
+        residual_in_fp32: Whether to compute residuals in fp32 (default: True)
+
+        # Bidirectional Processing
+        bidirectional: Enable bidirectional processing (default: True)
+        bidirectional_strategy: How to combine forward/backward sequences ("add" or "ew_multiply") (default: "add")
+        bidirectional_weight_tie: Tie weights between input/output projections (default: True)
+        
+        # Reverse-Complement Processing
+        rcps: Enable reverse-complement equivariance (default: False)
+        complement_map: Token to complement mapping, required if rcps=True (default: None)
+        
+        # Component Configurations
+        initializer_cfg: Weight initialization settings
+            rescale_prenorm_residual: Rescale residuals by 1/√N (default: True)
+            initializer_range: Weight initialization std dev (default: 0.02)
+            n_residuals_per_layer: Residual connections per layer (default: 1)
+        
+        layer_cfg: Layer settings
+            mode: Layer architecture type (default: "mamba-only")
+            mamba_cfg: Mamba-specific settings (default: CaduceusMambaConfig()):
+                version: Mamba version (default: "v2")
+                ssm_cfg: Optional SSM configuration (default: None)
+
+        norm_cfg: Normalization settings
+            fused_add_norm: Use fused add+norm operations (default: True)
+            rms_norm: Use RMSNorm instead of LayerNorm (default: True)
+            norm_epsilon: Normalization stability term (default: 1e-5)
+
+    Example:
+        ```python
+        config = CaduceusConfig(
+            d_model=2560,
+            n_layer=64,
+            vocab_size=tokenizer.vocab_size,
+            complement_map=tokenizer.complement_map,
+            rcps=True
+        )
+        ```
+    """
     model_type = "caduceus"
 
     def __init__(
             self,
-            # From original MambaConfig
             d_model: int = 2560,
             n_layer: int = 64,
             vocab_size: int = 50277,
-            ssm_cfg: Optional[dict] = None,
-            rms_norm: bool = True,
             residual_in_fp32: bool = True,
-            fused_add_norm: bool = True,
             pad_vocab_size_multiple: int = 8,
-
-            # Not in original MambaConfig, but default arg in create_block in mamba_ssm repo; used in layer norm
-            norm_epsilon: float = 1e-5,
-
-            # Used in init_weights
-            initializer_cfg: Optional[dict] = None,
-
-            # Caduceus-specific params
             bidirectional: bool = True,
-            bidirectional_strategy: Union[str, None] = "add",
+            bidirectional_strategy: Optional[Literal["add", "ew_multiply"]] = "add",
             bidirectional_weight_tie: bool = True,
             rcps: bool = False,
-            complement_map: Optional[dict] = None,  # used for RCPSEmbedding / RCPSLMHead
+            complement_map: Optional[Dict[str, Any]] = None,
+            initializer_cfg: Optional[ConfigType[CaduceusInitializerConfig]] = None,
+            layer_cfg: Optional[ConfigType[CaduceusLayerConfig]] = None,
+            norm_cfg: Optional[ConfigType[CaduceusNormConfig]] = None,
             **kwargs,
     ):
         super().__init__(**kwargs)
         self.d_model = d_model
         self.n_layer = n_layer
         self.vocab_size = vocab_size
-        self.ssm_cfg = ssm_cfg
-        self.rms_norm = rms_norm
         self.residual_in_fp32 = residual_in_fp32
-        self.fused_add_norm = fused_add_norm
         self.pad_vocab_size_multiple = pad_vocab_size_multiple
-        self.norm_epsilon = norm_epsilon
-        self.initializer_cfg = initializer_cfg
         self.bidirectional = bidirectional
         self.bidirectional_strategy = bidirectional_strategy
         self.bidirectional_weight_tie = bidirectional_weight_tie
         self.rcps = rcps
         self.complement_map = complement_map
+
+        # Handle config objects that might be dictionaries for nested configs; see:
+        # - Nesting config implementation: [transformers/configuration_utils.py#L891](https://github.com/huggingface/transformers/blob/v4.48.0/src/transformers/configuration_utils.py#L891)
+        # - Nested config example (CLIP): [clip/configuration_clip.py#L100](https://github.com/huggingface/transformers/blob/bef7dded22a2800908d034540d49837e9ef6fd39/src/transformers/models/clip/configuration_clip.py#L100)
+        self.initializer_cfg = CaduceusInitializerConfig(**initializer_cfg) if isinstance(initializer_cfg, dict) else initializer_cfg or CaduceusInitializerConfig()
+        self.layer_cfg = CaduceusLayerConfig(**layer_cfg) if isinstance(layer_cfg, dict) else layer_cfg or CaduceusLayerConfig()
+        self.norm_cfg = CaduceusNormConfig(**norm_cfg) if isinstance(norm_cfg, dict) else norm_cfg or CaduceusNormConfig()
+

--- a/caduceus/modeling_caduceus.py
+++ b/caduceus/modeling_caduceus.py
@@ -5,10 +5,11 @@
 import inspect
 import math
 from functools import partial
-from typing import Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 import torch
 from mamba_ssm.modules.mamba_simple import Mamba
+from mamba_ssm.modules.mamba2 import Mamba2
 try:
     from mamba_ssm.modules.mamba_simple import Block  # Legacy mambav1 file structure
 except ImportError:
@@ -32,16 +33,17 @@ from .modeling_rcps import RCPSAddNormWrapper, RCPSEmbedding, RCPSLMHead, RCPSMa
 
 def create_block(
         d_model,
-        ssm_cfg=None,
-        norm_epsilon=1e-5,
-        rms_norm=False,
-        residual_in_fp32=False,
-        fused_add_norm=False,
-        layer_idx=None,
-        bidirectional=True,
-        bidirectional_strategy="add",
-        bidirectional_weight_tie=True,
-        rcps=False,
+        *,
+        ssm_cfg,
+        norm_epsilon,
+        rms_norm,
+        residual_in_fp32,
+        fused_add_norm,
+        layer_idx,
+        bidirectional,
+        bidirectional_strategy,
+        bidirectional_weight_tie,
+        rcps,
         device=None,
         dtype=None,
 ):
@@ -90,19 +92,26 @@ class BiMambaWrapper(nn.Module):
     def __init__(
             self,
             d_model: int,
+            mamba_version: Literal["v1", "v2"] = "v1",
             bidirectional: bool = True,
-            bidirectional_strategy: Optional[str] = "add",
+            bidirectional_strategy: Literal["add", "ew_multiply"] = "add",
             bidirectional_weight_tie: bool = True,
             **mamba_kwargs,
     ):
         super().__init__()
-        if bidirectional and bidirectional_strategy is None:
-            bidirectional_strategy = "add"  # Default strategy: `add`
-        if bidirectional and bidirectional_strategy not in ["add", "ew_multiply"]:
-            raise NotImplementedError(f"`{bidirectional_strategy}` strategy for bi-directionality is not implemented!")
+        if bidirectional and bidirectional_strategy not in ("add", "ew_multiply"):
+            raise NotImplementedError(f"Unrecognized {bidirectional_strategy=!r}; must be one of ('add', 'ew_multiply')")
         self.bidirectional = bidirectional
         self.bidirectional_strategy = bidirectional_strategy
-        self.mamba_fwd = Mamba(
+
+        if mamba_version not in ("v1", "v2"):
+            raise NotImplementedError(f"Unrecognized {mamba_version=!r}; must be one of ('v1', 'v2')")
+        if mamba_version == "v1":
+            block_cls = Mamba
+        else:
+            block_cls = Mamba2
+        
+        self.mamba_fwd = block_cls(
             d_model=d_model,
             **mamba_kwargs
         )
@@ -173,7 +182,7 @@ class CaduceusMixerModel(nn.Module):
         super().__init__()
         factory_kwargs = {"device": device, "dtype": dtype}
 
-        self.fused_add_norm = config.fused_add_norm
+        self.fused_add_norm = config.norm_cfg.fused_add_norm
         self.rcps = config.rcps
         self.residual_in_fp32 = config.residual_in_fp32
 
@@ -184,7 +193,7 @@ class CaduceusMixerModel(nn.Module):
         # Add -> LN -> Attn / MLP / Mixer, returning both the residual branch (output of Add) and
         # the main branch (output of MLP / Mixer). The model definition is unchanged.
         # This is for performance reason: we can fuse add + layer_norm.
-        if config.fused_add_norm:
+        if config.norm_cfg.fused_add_norm:
             if layer_norm_fn is None or rms_norm_fn is None:
                 raise ImportError("Failed to import Triton LayerNorm / RMSNorm kernels")
 
@@ -192,11 +201,11 @@ class CaduceusMixerModel(nn.Module):
             [
                 create_block(
                     config.d_model,
-                    ssm_cfg=config.ssm_cfg,
-                    norm_epsilon=config.norm_epsilon,
-                    rms_norm=config.rms_norm,
+                    ssm_cfg=config.layer_cfg.mamba_cfg.ssm_cfg,
+                    norm_epsilon=config.norm_cfg.norm_epsilon,
+                    rms_norm=config.norm_cfg.rms_norm,
                     residual_in_fp32=config.residual_in_fp32,
-                    fused_add_norm=config.fused_add_norm,
+                    fused_add_norm=config.norm_cfg.fused_add_norm,
                     layer_idx=i,
                     bidirectional=config.bidirectional,
                     bidirectional_strategy=config.bidirectional_strategy,
@@ -208,10 +217,10 @@ class CaduceusMixerModel(nn.Module):
             ]
         )
 
-        norm_f = (nn.LayerNorm if not config.rms_norm else RMSNorm)(
-            config.d_model, eps=config.norm_epsilon, **factory_kwargs
+        norm_f = (nn.LayerNorm if not config.norm_cfg.rms_norm else RMSNorm)(
+            config.d_model, eps=config.norm_cfg.norm_epsilon, **factory_kwargs
         )
-        self.norm_f = norm_f if (config.fused_add_norm or not config.rcps) else RCPSAddNormWrapper(norm_f)
+        self.norm_f = norm_f if (config.norm_cfg.fused_add_norm or not config.rcps) else RCPSAddNormWrapper(norm_f)
 
     def forward(self, input_ids, inputs_embeds=None, output_hidden_states=False):
         """Mixer forward."""
@@ -301,19 +310,16 @@ class CaduceusPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = False
     _no_split_modules = ["BiMambaWrapper"]
 
-    def _init_weights(
-            self,
-            module,
-            initializer_range=0.02,  # Now only used for embedding layer.
-            **kwargs,
-    ):
-        """Adapted from: https://github.com/state-spaces/mamba/blob/main/mamba_ssm/models/mixer_seq_simple.py"""
-
+    def _init_weights(self, module, **kwargs):
+        """Initialize weights.
+        
+        Adapted from: https://github.com/state-spaces/mamba/blob/main/mamba_ssm/models/mixer_seq_simple.py
+        """
         n_layer = self.config.n_layer
-        initialized_cfg = self.config.initializer_cfg if self.config.initializer_cfg is not None else {}
-        rescale_prenorm_residual = initialized_cfg.get("rescale_prenorm_residual", True)
-        initializer_range = initialized_cfg.get("initializer_range", initializer_range)
-        n_residuals_per_layer = initialized_cfg.get("n_residuals_per_layer", 1)
+        initialized_cfg = self.config.initializer_cfg
+        rescale_prenorm_residual = initialized_cfg.rescale_prenorm_residual
+        initializer_range = initialized_cfg.initializer_range
+        n_residuals_per_layer = initialized_cfg.n_residuals_per_layer
 
         if isinstance(module, nn.Linear):
             if module.bias is not None:
@@ -518,9 +524,9 @@ class CaduceusForSequenceClassification(CaduceusPreTrainedModel):
         self.post_init()
         self.init_scorer()
 
-    def init_scorer(self, initializer_range=0.02):
-        initializer_range = self.config.initializer_cfg.get("initializer_range", initializer_range) \
-            if self.config.initializer_cfg is not None else initializer_range
+    def init_scorer(self):
+        """Initialize the scoring head."""
+        initializer_range = self.config.initializer_cfg.initializer_range
         self.score.weight.data.normal_(std=initializer_range)
 
     def get_input_embeddings(self):

--- a/caduceus/modeling_rcps.py
+++ b/caduceus/modeling_rcps.py
@@ -138,8 +138,7 @@ class RCPSMambaBlock(nn.Module):
             norm_cls=nn.LayerNorm,
             fused_add_norm=False,
             residual_in_fp32=False,
-            device=None,  # Keep for consistency with original Mamba Block
-            dtype=None,  # Keep for consistency with original Mamba Block
+            **kwargs
     ):
         """RCPS version of simple block wrapping a mixer class with LayerNorm/RMSNorm and residual connection.
 
@@ -156,6 +155,11 @@ class RCPSMambaBlock(nn.Module):
             assert isinstance(
                 self.norm, (nn.LayerNorm, RMSNorm)
             ), "Only LayerNorm and RMSNorm are supported for fused_add_norm"
+        
+        # Warn about unused kwargs (e.g. device, dtype)
+        if kwargs:
+            import warnings
+            warnings.warn(f"Unused kwargs in RCPSMambaBlock: {list(kwargs.keys())}")
 
     def forward(
         self, hidden_states: Tensor, residual: Optional[Tensor] = None, inference_params=None


### PR DESCRIPTION
This builds from https://github.com/kuleshov-group/caduceus/commit/49e3204dfba5bd36b9c6405bca6b0396e04ab9d2 to refactor configurations in advance of supporting Mamba1 / Mamba2 better.  It also adds better support for configuration of multiple layer types.

I will tackle a more comprehensive integration of Mamba2 next.  I wanted to put up this PR though as a more minimal example of what I'd like to change about the config first.

Do you have any thoughts on nesting `PretrainedConfig` config instances @Skylion007?  I went that route when I saw this: [v4.48.0/src/transformers/configuration_utils.py#L891](https://github.com/huggingface/transformers/blob/v4.48.0/src/transformers/configuration_utils.py#L891) (i.e. CLIP is an example of a model that has a [config](https://github.com/huggingface/transformers/blob/bef7dded22a2800908d034540d49837e9ef6fd39/src/transformers/models/clip/configuration_clip.py#L100) like this).
