### PR TITLE
Integrate and test Mamba2

### DIFF
--- a/caduceus/configuration_caduceus.py
+++ b/caduceus/configuration_caduceus.py
@@ -2,54 +2,169 @@
 
 """
 
-from typing import Optional, Union
+from typing import Literal, Optional, Union, TypeVar, Dict, Any
 
 from transformers import PretrainedConfig
 
 
+T = TypeVar('T', bound=PretrainedConfig)
+ConfigType = Union[Dict[str, Any], T]
+
+
+class CaduceusMambaConfig(PretrainedConfig):
+    """Configuration for Mamba SSM layers.
+
+    For example `ssm_cfg` options, see:
+      - v1: [mamba_ssm/modules/mamba_simple.py#L31-L50](https://github.com/state-spaces/mamba/blob/9182c93c9acb3e4ccac55a18a52c228d870d60bc/mamba_ssm/modules/mamba_simple.py#L31-L50)
+      - v2: [mamba_ssm/modules/mamba2.py#L37-L66](https://github.com/state-spaces/mamba/blob/9182c93c9acb3e4ccac55a18a52c228d870d60bc/mamba_ssm/modules/mamba2.py#L37-L66)
+    """
+    def __init__(
+        self,
+        version: Literal["v1", "v2"] = "v2",
+        ssm_cfg: Optional[Dict[str, Any]] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.version = version
+        self.ssm_cfg = ssm_cfg
+
+
+class CaduceusLayerConfig(PretrainedConfig):
+    def __init__(
+        self,
+        mode: Literal["mamba-only"] = "mamba-only",
+        mamba_cfg: Optional[ConfigType[CaduceusMambaConfig]] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.mode = mode
+        self.mamba_cfg = CaduceusMambaConfig(**mamba_cfg) if isinstance(mamba_cfg, dict) else mamba_cfg or CaduceusMambaConfig()
+
+
+class CaduceusNormConfig(PretrainedConfig):
+    def __init__(
+        self,
+        fused_add_norm: bool = True,
+        rms_norm: bool = True,
+        norm_epsilon: float = 1e-5,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.fused_add_norm = fused_add_norm
+        self.rms_norm = rms_norm
+        self.norm_epsilon = norm_epsilon
+
+
+class CaduceusInitializerConfig(PretrainedConfig):
+    def __init__(
+        self,
+        rescale_prenorm_residual: bool = True,
+        initializer_range: float = 0.02,
+        n_residuals_per_layer: int = 1,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.rescale_prenorm_residual = rescale_prenorm_residual
+        self.initializer_range = initializer_range
+        self.n_residuals_per_layer = n_residuals_per_layer
+
+
 class CaduceusConfig(PretrainedConfig):
-    """Config that extends the original MambaConfig with params relevant to bi-directionality and RC equivariance."""
+    """Configuration class for Caduceus model.
+
+    Args:
+        # Model Architecture
+        d_model: Hidden dimension of the model (default: 2560)
+        n_layer: Number of layers in the model (default: 64)
+        vocab_size: Size of the vocabulary (default: 50277)
+        pad_vocab_size_multiple: Pad vocabulary size to be divisible by this value (default: 8)
+        residual_in_fp32: Whether to compute residuals in fp32 (default: True)
+
+        # Bidirectional Processing
+        bidirectional: Enable bidirectional processing (default: True)
+        bidirectional_strategy: How to combine forward/backward sequences ("add" or "ew_multiply") (default: "add")
+        bidirectional_weight_tie: Tie weights between input/output projections (default: True)
+        
+        # Reverse-Complement Processing
+        rcps: Enable reverse-complement equivariance (default: False)
+        complement_map: Token to complement mapping, required if rcps=True (default: None)
+        
+        # Component Configurations
+        initializer_cfg: Weight initialization settings
+            rescale_prenorm_residual: Rescale residuals by 1/√N (default: True)
+            initializer_range: Weight initialization std dev (default: 0.02)
+            n_residuals_per_layer: Residual connections per layer (default: 1)
+        
+        layer_cfg: Layer settings
+            mode: Layer architecture type (default: "mamba-only")
+            mamba_cfg: Mamba-specific settings (default: CaduceusMambaConfig()):
+                version: Mamba version (default: "v2")
+                ssm_cfg: Optional SSM configuration (default: None)
+
+        norm_cfg: Normalization settings
+            fused_add_norm: Use fused add+norm operations (default: True)
+            rms_norm: Use RMSNorm instead of LayerNorm (default: True)
+            norm_epsilon: Normalization stability term (default: 1e-5)
+
+    Example:
+        ```python
+        from caduceus.tokenization_caduceus import CaduceusTokenizer
+        from caduceus.configuration_caduceus import CaduceusConfig
+
+        tokenizer = CaduceusTokenizer()
+        config = CaduceusConfig(
+            d_model=2560,
+            n_layer=64,
+            vocab_size=tokenizer.vocab_size,
+            complement_map=tokenizer.complement_map,
+            rcps=True
+        )
+        ```
+    """
     model_type = "caduceus"
 
     def __init__(
-            self,
-            # From original MambaConfig
-            d_model: int = 2560,
-            n_layer: int = 64,
-            vocab_size: int = 50277,
-            ssm_cfg: Optional[dict] = None,
-            rms_norm: bool = True,
-            residual_in_fp32: bool = True,
-            fused_add_norm: bool = True,
-            pad_vocab_size_multiple: int = 8,
-
-            # Not in original MambaConfig, but default arg in create_block in mamba_ssm repo; used in layer norm
-            norm_epsilon: float = 1e-5,
-
-            # Used in init_weights
-            initializer_cfg: Optional[dict] = None,
-
-            # Caduceus-specific params
-            bidirectional: bool = True,
-            bidirectional_strategy: Union[str, None] = "add",
-            bidirectional_weight_tie: bool = True,
-            rcps: bool = False,
-            complement_map: Optional[dict] = None,  # used for RCPSEmbedding / RCPSLMHead
-            **kwargs,
+        self,
+        d_model: int = 2560,
+        n_layer: int = 64,
+        vocab_size: int = 50277,
+        residual_in_fp32: bool = True,
+        pad_vocab_size_multiple: int = 8,
+        bidirectional: bool = True,
+        bidirectional_strategy: Optional[Literal["add", "ew_multiply"]] = "add",
+        bidirectional_weight_tie: bool = True,
+        rcps: bool = False,
+        complement_map: Optional[Dict[str, Any]] = None,
+        initializer_cfg: Optional[ConfigType[CaduceusInitializerConfig]] = None,
+        layer_cfg: Optional[ConfigType[CaduceusLayerConfig]] = None,
+        norm_cfg: Optional[ConfigType[CaduceusNormConfig]] = None,
     ):
-        super().__init__(**kwargs)
+        super().__init__()
         self.d_model = d_model
         self.n_layer = n_layer
         self.vocab_size = vocab_size
-        self.ssm_cfg = ssm_cfg
-        self.rms_norm = rms_norm
         self.residual_in_fp32 = residual_in_fp32
-        self.fused_add_norm = fused_add_norm
         self.pad_vocab_size_multiple = pad_vocab_size_multiple
-        self.norm_epsilon = norm_epsilon
-        self.initializer_cfg = initializer_cfg
         self.bidirectional = bidirectional
         self.bidirectional_strategy = bidirectional_strategy
         self.bidirectional_weight_tie = bidirectional_weight_tie
         self.rcps = rcps
         self.complement_map = complement_map
+
+        # Handle config objects that might be dictionaries for nested configs; see:
+        # - Nesting config implementation: [transformers/configuration_utils.py#L891](https://github.com/huggingface/transformers/blob/v4.48.0/src/transformers/configuration_utils.py#L891)
+        # - Nested config example (CLIP): [clip/configuration_clip.py#L100](https://github.com/huggingface/transformers/blob/bef7dded22a2800908d034540d49837e9ef6fd39/src/transformers/models/clip/configuration_clip.py#L100)
+        self.initializer_cfg = CaduceusInitializerConfig(**initializer_cfg) if isinstance(initializer_cfg, dict) else initializer_cfg or CaduceusInitializerConfig()
+        self.layer_cfg = CaduceusLayerConfig(**layer_cfg) if isinstance(layer_cfg, dict) else layer_cfg or CaduceusLayerConfig()
+        self.norm_cfg = CaduceusNormConfig(**norm_cfg) if isinstance(norm_cfg, dict) else norm_cfg or CaduceusNormConfig()
+
+        # Pre-condition checks
+        if  self.bidirectional and self.bidirectional_strategy not in (vals := ("add", "ew_multiply")):
+            raise NotImplementedError(f"Unrecognized {self.bidirectional_strategy=!r}; must be one of {vals}")
+        if self.layer_cfg.mode not in (vals := ("mamba-only", "mamba-rcps")):
+            raise NotImplementedError(f"Unrecognized {self.layer_cfg.mode=!r}; must be one of {vals}")
+        if self.layer_cfg.mamba_cfg.version not in (vals := ("v1", "v2")):
+            raise NotImplementedError(f"Unrecognized {self.layer_cfg.mamba_cfg.version=!r}; must be one of {vals}")
+        if self.rcps and self.complement_map is None:
+            raise ValueError("A `complement_map` must be provided if rcps=True")
+

--- a/caduceus/modeling_rcps.py
+++ b/caduceus/modeling_rcps.py
@@ -132,23 +132,22 @@ class RCPSAddNormWrapper(RCPSWrapper):
 
 class RCPSMambaBlock(nn.Module):
     def __init__(
-            self,
-            dim,
-            mixer_cls,
-            norm_cls=nn.LayerNorm,
-            fused_add_norm=False,
-            residual_in_fp32=False,
-            device=None,  # Keep for consistency with original Mamba Block
-            dtype=None,  # Keep for consistency with original Mamba Block
+        self,
+        dim,
+        mixer_cls,
+        mlp_cls=nn.Identity,
+        norm_cls=nn.LayerNorm,
+        fused_add_norm=False,
+        residual_in_fp32=False,
     ):
         """RCPS version of simple block wrapping a mixer class with LayerNorm/RMSNorm and residual connection.
 
-        Adapted from: https://github.com/state-spaces/mamba/blob/main/mamba_ssm/modules/mamba_simple.py
+        Adapted from: https://github.com/state-spaces/mamba/blob/9182c93c9acb3e4ccac55a18a52c228d870d60bc/mamba_ssm/modules/block.py
         """
         super().__init__()
         self.residual_in_fp32 = residual_in_fp32
         self.fused_add_norm = fused_add_norm
-        self.mixer = RCPSWrapper(mixer_cls(dim))
+        self.mixer = RCPSWrapper(mixer_cls())
         norm_f = norm_cls(dim)
         self.norm = norm_f if fused_add_norm else RCPSAddNormWrapper(norm_f)
         if self.fused_add_norm:

--- a/caduceus/tests/test_rcps.py
+++ b/caduceus/tests/test_rcps.py
@@ -2,6 +2,7 @@
 
 """
 
+from typing import Literal
 import pytest
 import torch
 from torch import nn
@@ -19,26 +20,112 @@ from caduceus.modeling_rcps import (
 from caduceus.modeling_caduceus import CaduceusConfig, CaduceusMixerModel, CaduceusForMaskedLM, create_block
 
 
-@pytest.mark.parametrize("batch_size", [4])
-@pytest.mark.parametrize("seq_len", [512])
-@pytest.mark.parametrize("d_model", [256])
-@pytest.mark.parametrize("dtype", [torch.float32])
-def test_rcps_embedding(batch_size, seq_len, d_model, dtype):
-    # Set tolerance
-    device = torch.device("cpu")
-    rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
-    if dtype == torch.bfloat16:
-        rtol, atol = 3e-2, 5e-2
-    # Set seed
-    torch.random.manual_seed(0)
-
-    # Define complement map
+def get_tokenizer_mappings():
     str_to_id = {"[CLS]": 0, "[MASK]": 1, "A": 2, "C": 3, "G": 4, "T": 5, "N": 6}
     complement_map = {"A": "T", "C": "G", "G": "C", "T": "A"}
     complement_map = {
         str_to_id[k]: str_to_id[complement_map[k]] if k in complement_map.keys() else v
         for k, v in str_to_id.items()
     }
+            
+    return str_to_id, complement_map
+
+def get_tokenized_inputs(str_to_id, complement_map, batch_size, seq_len, device):
+    input_ids = torch.randint(low=1, high=len(str_to_id), size=(batch_size, seq_len), device=device)
+    rc_input_ids = torch.flip(input_ids, dims=[-1]).to("cpu").apply_(lambda t: complement_map[t]).to(device)
+    return input_ids, rc_input_ids
+
+def create_test_config(**kwargs):
+    """Create a CaduceusConfig with default test settings.
+    
+    Args:
+        **kwargs: Override any config parameters.
+        
+    Returns:
+        CaduceusConfig: Configuration object with test defaults.
+    """
+    # Get tokenizer mappings
+    _, complement_map = get_tokenizer_mappings()
+
+    # Default config values
+    defaults = {
+        "d_model": 128,
+        "n_layer": 2,
+        "vocab_size": 12,
+        "residual_in_fp32": False,
+        "pad_vocab_size_multiple": 8,
+        "bidirectional": True,
+        "bidirectional_strategy": "add",
+        "bidirectional_weight_tie": True,
+        "rcps": True,
+        "complement_map": complement_map,
+    }
+
+    if (mamba_cfg := kwargs.get("layer_cfg", {}).get("mamba_cfg", {})).get("version", "v1") == "v2":
+        # Provide defaults for v2 Mamba configs that ensure 
+        # `d_model * expand / headdim` is a multiple of 8 when
+        # using the default `d_model` value set above. See:
+        # https://github.com/state-spaces/mamba/issues/351#issuecomment-2167091940
+        if "ssm_cfg" not in mamba_cfg:
+            mamba_cfg["ssm_cfg"] = {"headdim": 32, "expand": 2}
+
+    # Override defaults with any provided kwargs
+    config_args = {**defaults, **kwargs}
+    
+    config = CaduceusConfig(**config_args)
+
+    if config.layer_cfg.mamba_cfg.version == "v2":
+        # Check that `d_model * expand / headdim` is a multiple of 8
+        ssm_cfg = config.layer_cfg.mamba_cfg.ssm_cfg or {}
+        for param in ["headdim", "expand"]:
+            if param not in ssm_cfg:
+                raise ValueError(
+                    f"Parameter {param!r} is required in v2 Mamba configs for testing to avoid this issue: "
+                    "https://github.com/state-spaces/mamba/issues/351#issuecomment-2167091940"
+                )
+        dim = config.d_model * ssm_cfg["expand"] / ssm_cfg["headdim"]
+        if dim % 8 != 0:
+            raise ValueError(
+                f"For v2 Mamba configs, d_model * expand / headdim must be a multiple of 8 (got {dim}).  See: "
+                "https://github.com/state-spaces/mamba/issues/351#issuecomment-2167091940"
+            )
+    return config
+
+@pytest.fixture
+def device():
+    """Fixture to provide the compute device."""
+    return torch.device("cuda")
+
+def mamba_dtype_supported(version: Literal["v1", "v2"], device: torch.device, dtype: torch.dtype) -> bool:
+    # Skip fp32 tests for Mamba v2 on older GPUs due to:
+    # https://github.com/triton-lang/triton/issues/4813
+    major, _ = torch.cuda.get_device_capability(device)
+    if (
+        version == "v2" 
+        and torch.finfo(dtype).bits >= torch.finfo(torch.float32).bits 
+        and major < 8
+    ):
+        return False
+    return True
+
+def skip_if_mamba_dtype_not_supported(version: Literal["v1", "v2"], device: torch.device, dtype: torch.dtype) -> None:
+    if not mamba_dtype_supported(version, device, dtype):
+        pytest.skip("Mamba v2 fp32+ tests are not supported on this GPU")
+
+@pytest.mark.parametrize("batch_size", [4])
+@pytest.mark.parametrize("seq_len", [512])
+@pytest.mark.parametrize("d_model", [256])
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_rcps_embedding(device, batch_size, seq_len, d_model, dtype):
+    # Set tolerance
+    rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
+    if dtype == torch.bfloat16:
+        rtol, atol = 3e-2, 5e-2
+    # Set seed
+    torch.random.manual_seed(0)
+
+    # Get tokenizer mappings
+    str_to_id, complement_map = get_tokenizer_mappings()
     vocab_size = 12
     pad_vocab_size_multiple = 8
     if vocab_size % pad_vocab_size_multiple != 0:
@@ -48,8 +135,7 @@ def test_rcps_embedding(batch_size, seq_len, d_model, dtype):
             complement_map[i] = i
 
     # Generate random sequences
-    input_ids = torch.randint(low=1, high=len(str_to_id), size=(batch_size, seq_len), device=device)
-    rc_input_ids = torch.flip(input_ids, dims=[-1]).to("cpu").apply_(lambda t: complement_map[t]).to(device)
+    input_ids, rc_input_ids = get_tokenized_inputs(str_to_id, complement_map, batch_size, seq_len, device)
 
     # Test RC equivariance of embedding layer
     factory_kwargs = {"device": device, "dtype": dtype}
@@ -72,9 +158,8 @@ def test_rcps_embedding(batch_size, seq_len, d_model, dtype):
 @pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize("d_model", [128])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-def test_rcps_wrapper(batch_size, seq_len, d_model, dtype):
+def test_rcps_wrapper(device, batch_size, seq_len, d_model, dtype):
     # Set tolerance
-    device = torch.device("cuda")
     rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
     if dtype == torch.bfloat16:
         rtol, atol = 3e-2, 5e-2
@@ -107,9 +192,10 @@ def test_rcps_wrapper(batch_size, seq_len, d_model, dtype):
 @pytest.mark.parametrize("seq_len", [1024])
 @pytest.mark.parametrize("d_model", [128])
 @pytest.mark.parametrize("dtype", [torch.float16])
-def test_rcps_add_norm_wrapper(batch_size, seq_len, d_model, dtype):
+def test_rcps_add_norm_wrapper(device, batch_size, seq_len, d_model, dtype):
+    if RMSNorm is None:
+        pytest.skip("RMSNorm is not available")
     # Set tolerance
-    device = torch.device("cuda")
     rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
     if dtype == torch.bfloat16:
         rtol, atol = 3e-2, 5e-2
@@ -139,9 +225,10 @@ def test_rcps_add_norm_wrapper(batch_size, seq_len, d_model, dtype):
 @pytest.mark.parametrize("bidirectional", [True, False])
 @pytest.mark.parametrize("fused_add_norm", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float16])
-def test_rcps_mamba_block_wrapper(batch_size, seq_len, d_model, bidirectional, fused_add_norm, dtype):
+@pytest.mark.parametrize("mamba_version", ["v1", "v2"])
+def test_rcps_mamba_block_wrapper(device, batch_size, seq_len, d_model, bidirectional, fused_add_norm, dtype, mamba_version):
+    skip_if_mamba_dtype_not_supported(mamba_version, device, dtype)
     # Set tolerance
-    device = torch.device("cuda")
     rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
     if dtype == torch.bfloat16:
         rtol, atol = 3e-2, 5e-2
@@ -151,25 +238,19 @@ def test_rcps_mamba_block_wrapper(batch_size, seq_len, d_model, bidirectional, f
     # Generate random sequence with 2 * d_model channels
     x = torch.randn(batch_size, seq_len, d_model * 2, device=device, dtype=dtype)
     rc_x = torch.flip(x, dims=[-2, -1])
-
-    ssm_cfg = {
-        "d_state": 16, "d_conv": 4, "expand": 2, "dt_rank": "auto", "dt_min": 0.001, "dt_max": 0.1, "dt_init": "random",
-        "dt_scale": 1.0, "dt_init_floor": 1e-4, "conv_bias": True, "bias": False, "use_fast_path": True
-    }
     factory_kwargs = {"device": device, "dtype": dtype}
 
-    mamba_block = create_block(
-        d_model,
-        ssm_cfg=ssm_cfg,
-        norm_epsilon=1e-5,
-        rms_norm=True,
+    config = create_test_config(
+        d_model=d_model,
         residual_in_fp32=True,
-        fused_add_norm=fused_add_norm,
-        layer_idx=0,
         bidirectional=bidirectional,
-        bidirectional_strategy="add",
         bidirectional_weight_tie=True,
-        rcps=True,
+        norm_cfg=dict(fused_add_norm=fused_add_norm),
+        layer_cfg=dict(mamba_cfg=dict(version=mamba_version))
+    )
+    mamba_block = create_block(
+        config=config,
+        layer_idx=0,
         **factory_kwargs
     )
 
@@ -189,13 +270,20 @@ def test_rcps_mamba_block_wrapper(batch_size, seq_len, d_model, bidirectional, f
         assert torch.allclose(f.detach(), r.detach(), rtol=rtol, atol=atol)
 
 
-@pytest.mark.parametrize("batch_size", [2, 4])
-@pytest.mark.parametrize("seq_len", [1, 1024, 2048])
-@pytest.mark.parametrize("d_model", [2, 128, 256])
+@pytest.mark.parametrize("batch_size", [2])
+@pytest.mark.parametrize("seq_len", [1024, 2048])
+@pytest.mark.parametrize("n_layer", [1, 2])
+@pytest.mark.parametrize("d_model", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-def test_rcps_lm_head(batch_size, seq_len, d_model, dtype):
+@pytest.mark.parametrize("fused_add_norm", [True, False])
+@pytest.mark.parametrize("bidirectional", [False, True])
+@pytest.mark.parametrize("bidirectional_weight_tie", [False, True])
+@pytest.mark.parametrize("mamba_version", ["v1", "v2"])
+def test_rcps_backbone(device, batch_size, seq_len, n_layer, d_model, dtype, fused_add_norm,
+                       bidirectional, bidirectional_weight_tie, mamba_version):
+    skip_if_mamba_dtype_not_supported(mamba_version, device, dtype)
+
     # Set tolerance
-    device = torch.device("cuda")
     rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
     if dtype == torch.bfloat16:
         rtol, atol = 3e-2, 5e-2
@@ -203,18 +291,67 @@ def test_rcps_lm_head(batch_size, seq_len, d_model, dtype):
     # Set seed
     torch.random.manual_seed(0)
 
-    # Define complement map
-    str_to_id = {"[CLS]": 0, "[MASK]": 1, "A": 2, "C": 3, "G": 4, "T": 5, "N": 6}
-    complement_map = {"A": "T", "C": "G", "G": "C", "T": "A"}
-    complement_map = {
-        str_to_id[k]: str_to_id[complement_map[k]] if k in complement_map.keys() else v
-        for k, v in str_to_id.items()
-    }
+    # Setup CaduceusConfig
+    config = create_test_config(
+        d_model=d_model,
+        n_layer=n_layer,
+        residual_in_fp32=True,
+        bidirectional=bidirectional,
+        bidirectional_weight_tie=bidirectional_weight_tie,
+        norm_cfg=dict(fused_add_norm=fused_add_norm),
+        layer_cfg=dict(mamba_cfg=dict(version=mamba_version))
+    )
     factory_kwargs = {"device": device, "dtype": dtype}
+
+    # Instantiate model
+    backbone = CaduceusMixerModel(
+        config,
+        **factory_kwargs,
+    ).to(device)
+
+    # Generate random sequences
+    str_to_id, complement_map = get_tokenizer_mappings()
+    input_ids, rc_input_ids = get_tokenized_inputs(str_to_id, complement_map, batch_size, seq_len, device)
+
+    # Test RC equivariance of rc backbone
+    out = backbone(input_ids)[0]
+    rc_out = backbone(rc_input_ids)[0]
+    if isinstance(rc_out, tuple):
+        rc_out = tuple([torch.flip(r, dims=[1, 2]) for r in rc_out])
+        for f, r in zip(out, rc_out):
+            assert f.size() == (batch_size, seq_len, d_model * 2)
+            assert r.size() == (batch_size, seq_len, d_model * 2)
+            assert torch.allclose(f.detach(), r.detach(), rtol=rtol, atol=atol)
+    else:
+        # Hidden state size should double
+        assert tuple(out.size()) == (batch_size, seq_len, d_model * 2)
+        assert tuple(rc_out.size()) == (batch_size, seq_len, d_model * 2)
+        assert torch.allclose(out.detach(), torch.flip(rc_out.detach(), dims=[1, 2]), rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("batch_size", [2])
+@pytest.mark.parametrize("seq_len", [1, 1024, 2048])
+@pytest.mark.parametrize("d_model", [2, 128, 256])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize("mamba_version", ["v1", "v2"])
+def test_rcps_lm_head(device, batch_size, seq_len, d_model, dtype, mamba_version):
+    skip_if_mamba_dtype_not_supported(mamba_version, device, dtype)
+
+    # Set tolerance
+    rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
+    if dtype == torch.bfloat16:
+        rtol, atol = 3e-2, 5e-2
+
+    # Set seed
+    torch.random.manual_seed(0)
+
+    # Get tokenizer mappings
+    _, complement_map = get_tokenizer_mappings()
     vocab_size = 12
     if vocab_size > len(complement_map):
         for i in range(len(complement_map), vocab_size):
             complement_map[i] = i
+    factory_kwargs = {"device": device, "dtype": dtype}
 
     # Instantiate LM head
     lm_head = RCPSLMHead(
@@ -247,94 +384,18 @@ def test_rcps_lm_head(batch_size, seq_len, d_model, dtype):
     )
 
 
-@pytest.mark.parametrize("batch_size", [2, 4])
-@pytest.mark.parametrize("seq_len", [1024, 2048])
-@pytest.mark.parametrize("n_layer", [1, 2])
-@pytest.mark.parametrize("d_model", [128, 256])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-@pytest.mark.parametrize("fused_add_norm", [True, False])
-@pytest.mark.parametrize("bidirectional", [False, True])
-@pytest.mark.parametrize("bidirectional_weight_tie", [False, True])
-def test_rcps_backbone(batch_size, seq_len, n_layer, d_model, dtype, fused_add_norm,
-                       bidirectional, bidirectional_weight_tie):
-    # Set tolerance
-    device = torch.device("cuda")
-    rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
-    if dtype == torch.bfloat16:
-        rtol, atol = 3e-2, 5e-2
-
-    # Set seed
-    torch.random.manual_seed(0)
-
-    # Define complement map
-    str_to_id = {"[CLS]": 0, "[MASK]": 1, "A": 2, "C": 3, "G": 4, "T": 5, "N": 6}
-    complement_map = {"A": "T", "C": "G", "G": "C", "T": "A"}
-    complement_map = {
-        str_to_id[k]: str_to_id[complement_map[k]] if k in complement_map.keys() else v
-        for k, v in str_to_id.items()
-    }
-
-    # Setup CaduceusConfig
-    initializer_cfg = {"initializer_range": 0.02, "rescale_prenorm_residual": True, "n_residuals_per_layer": 1}
-    ssm_cfg = {
-        "d_state": 16, "d_conv": 4, "expand": 2, "dt_rank": "auto", "dt_min": 0.001, "dt_max": 0.1, "dt_init": "random",
-        "dt_scale": 1.0, "dt_init_floor": 1e-4, "conv_bias": True, "bias": False, "use_fast_path": True
-    }
-    config = CaduceusConfig(
-        d_model=d_model,
-        n_layer=n_layer,
-        vocab_size=12,
-        ssm_cfg=ssm_cfg,
-        rms_norm=True,
-        residual_in_fp32=False,
-        fused_add_norm=fused_add_norm,
-        pad_vocab_size_multiple=8,
-        norm_epsilon=1e-5,
-        initializer_cfg=initializer_cfg,
-        bidirectional=bidirectional,
-        bidirectional_strategy="add",
-        bidirectional_weight_tie=bidirectional_weight_tie,
-        rcps=True,
-        complement_map=complement_map,
-    )
-    factory_kwargs = {"device": device, "dtype": dtype}
-
-    # Instantiate model
-    backbone = CaduceusMixerModel(
-        config,
-        **factory_kwargs,
-    ).to(device)
-
-    # Generate random sequences
-    input_ids = torch.randint(low=1, high=len(str_to_id), size=(batch_size, seq_len), device=device)
-    rc_input_ids = torch.flip(input_ids, dims=[-1]).to("cpu").apply_(lambda t: complement_map[t]).to(device)
-
-    # Test RC equivariance of rc backbone
-    out = backbone(input_ids)[0]
-    rc_out = backbone(rc_input_ids)[0]
-    if isinstance(rc_out, tuple):
-        rc_out = tuple([torch.flip(r, dims=[1, 2]) for r in rc_out])
-        for f, r in zip(out, rc_out):
-            assert f.size() == (batch_size, seq_len, d_model * 2)
-            assert r.size() == (batch_size, seq_len, d_model * 2)
-            assert torch.allclose(f.detach(), r.detach(), rtol=rtol, atol=atol)
-    else:
-        # Hidden state size should double
-        assert tuple(out.size()) == (batch_size, seq_len, d_model * 2)
-        assert tuple(rc_out.size()) == (batch_size, seq_len, d_model * 2)
-        assert torch.allclose(out.detach(), torch.flip(rc_out.detach(), dims=[1, 2]), rtol=rtol, atol=atol)
-
-
-@pytest.mark.parametrize("batch_size", [2, 4])
+@pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize("seq_len", [1024, 2048])
 @pytest.mark.parametrize("n_layer", [1, 4])
 @pytest.mark.parametrize("d_model", [128, 256])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 @pytest.mark.parametrize("bidirectional", [False, True])
 @pytest.mark.parametrize("bidirectional_weight_tie", [False, True])
-def test_rcps_mamba_lm(batch_size, seq_len, n_layer, d_model, dtype, bidirectional, bidirectional_weight_tie):
+@pytest.mark.parametrize("mamba_version", ["v1", "v2"])
+def test_rcps_mamba_lm(device, batch_size, seq_len, n_layer, d_model, dtype, bidirectional, bidirectional_weight_tie, mamba_version):
+    skip_if_mamba_dtype_not_supported(mamba_version, device, dtype)
+
     # Set tolerance
-    device = torch.device("cuda")
     rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
     if dtype == torch.bfloat16:
         rtol, atol = 3e-2, 5e-2
@@ -342,36 +403,13 @@ def test_rcps_mamba_lm(batch_size, seq_len, n_layer, d_model, dtype, bidirection
     # Set seed
     torch.random.manual_seed(0)
 
-    # Define complement map
-    str_to_id = {"[CLS]": 0, "[MASK]": 1, "A": 2, "C": 3, "G": 4, "T": 5, "N": 6}
-    complement_map = {"A": "T", "C": "G", "G": "C", "T": "A"}
-    complement_map = {
-        str_to_id[k]: str_to_id[complement_map[k]] if k in complement_map.keys() else v
-        for k, v in str_to_id.items()
-    }
-
     # Setup CaduceusConfig
-    initializer_cfg = {"initializer_range": 0.02, "rescale_prenorm_residual": True, "n_residuals_per_layer": 1}
-    ssm_cfg = {
-        "d_state": 16, "d_conv": 4, "expand": 2, "dt_rank": "auto", "dt_min": 0.001, "dt_max": 0.1, "dt_init": "random",
-        "dt_scale": 1.0, "dt_init_floor": 1e-4, "conv_bias": True, "bias": False, "use_fast_path": True
-    }
-    config = CaduceusConfig(
+    config = create_test_config(
         d_model=d_model,
         n_layer=n_layer,
-        vocab_size=12,
-        ssm_cfg=ssm_cfg,
-        rms_norm=True,
-        residual_in_fp32=False,
-        fused_add_norm=True,
-        pad_vocab_size_multiple=8,
-        norm_epsilon=1e-5,
-        initializer_cfg=initializer_cfg,
         bidirectional=bidirectional,
-        bidirectional_strategy="add",
         bidirectional_weight_tie=bidirectional_weight_tie,
-        rcps=True,
-        complement_map=complement_map,
+        layer_cfg=dict(mamba_cfg=dict(version=mamba_version))
     )
     factory_kwargs = {"device": device, "dtype": dtype}
 
@@ -382,8 +420,8 @@ def test_rcps_mamba_lm(batch_size, seq_len, n_layer, d_model, dtype, bidirection
     ).to(device)
 
     # Generate random sequences
-    input_ids = torch.randint(low=1, high=len(str_to_id), size=(batch_size, seq_len), device=device)
-    rc_input_ids = torch.flip(input_ids, dims=[-1]).to("cpu").apply_(lambda t: complement_map[t]).to(device)
+    str_to_id, complement_map = get_tokenizer_mappings()
+    input_ids, rc_input_ids = get_tokenized_inputs(str_to_id, complement_map, batch_size, seq_len, device)
 
     # Test RC equivariance of rc backbone
     out = mamba_lm(input_ids)
@@ -413,9 +451,11 @@ def test_rcps_mamba_lm(batch_size, seq_len, n_layer, d_model, dtype, bidirection
 @pytest.mark.parametrize("dtype", [torch.float16])
 @pytest.mark.parametrize("bidirectional", [True, False])
 @pytest.mark.parametrize("bidirectional_weight_tie", [True])
-def test_collapse_invariance(batch_size, seq_len, n_layer, d_model, dtype, bidirectional, bidirectional_weight_tie):
+@pytest.mark.parametrize("mamba_version", ["v1", "v2"])
+def test_collapse_invariance(device, batch_size, seq_len, n_layer, d_model, dtype, bidirectional, bidirectional_weight_tie, mamba_version):
+    skip_if_mamba_dtype_not_supported(mamba_version, device, dtype)
+
     # Set tolerance
-    device = torch.device("cuda")
     rtol, atol = (6e-4, 2e-3) if dtype == torch.float32 else (3e-3, 5e-3)
     if dtype == torch.bfloat16:
         rtol, atol = 3e-2, 5e-2
@@ -423,36 +463,13 @@ def test_collapse_invariance(batch_size, seq_len, n_layer, d_model, dtype, bidir
     # Set seed
     torch.random.manual_seed(0)
 
-    # Define complement map
-    str_to_id = {"[CLS]": 0, "[MASK]": 1, "A": 2, "C": 3, "G": 4, "T": 5, "N": 6}
-    complement_map = {"A": "T", "C": "G", "G": "C", "T": "A"}
-    complement_map = {
-        str_to_id[k]: str_to_id[complement_map[k]] if k in complement_map.keys() else v
-        for k, v in str_to_id.items()
-    }
-
     # Setup CaduceusConfig
-    initializer_cfg = {"initializer_range": 0.02, "rescale_prenorm_residual": True, "n_residuals_per_layer": 1}
-    ssm_cfg = {
-        "d_state": 16, "d_conv": 4, "expand": 2, "dt_rank": "auto", "dt_min": 0.001, "dt_max": 0.1, "dt_init": "random",
-        "dt_scale": 1.0, "dt_init_floor": 1e-4, "conv_bias": True, "bias": False, "use_fast_path": True
-    }
-    config = CaduceusConfig(
+    config = create_test_config(
         d_model=d_model,
         n_layer=n_layer,
-        vocab_size=12,
-        ssm_cfg=ssm_cfg,
-        rms_norm=True,
-        residual_in_fp32=False,
-        fused_add_norm=True,
-        pad_vocab_size_multiple=8,
-        norm_epsilon=1e-5,
-        initializer_cfg=initializer_cfg,
         bidirectional=bidirectional,
-        bidirectional_strategy="add",
         bidirectional_weight_tie=bidirectional_weight_tie,
-        rcps=True,
-        complement_map=complement_map,
+        layer_cfg=dict(mamba_cfg=dict(version=mamba_version))
     )
     factory_kwargs = {"device": device, "dtype": dtype}
 
@@ -463,8 +480,8 @@ def test_collapse_invariance(batch_size, seq_len, n_layer, d_model, dtype, bidir
     ).to(device)
 
     # Generate random sequences
-    input_ids = torch.randint(low=1, high=len(str_to_id), size=(batch_size, seq_len), device=device)
-    rc_input_ids = torch.flip(input_ids, dims=[-1]).to("cpu").apply_(lambda t: complement_map[t]).to(device)
+    str_to_id, complement_map = get_tokenizer_mappings()
+    input_ids, rc_input_ids = get_tokenized_inputs(str_to_id, complement_map, batch_size, seq_len, device)
 
     # Test RC Invariance when collapsing output of backbone
     out = backbone(input_ids)[0]


### PR DESCRIPTION
This builds on https://github.com/eric-czech/caduceus/pull/2 to fully integrate Mamba2 and extend tests to run for both Mamba1 and Mamba2.  I hit two snags with this, namely:

1. I get this same Triton indexing bug when using fp32 instead of fp16: https://github.com/triton-lang/triton/issues/4813.  That issue suggests it's common with GPUs < SM80 (which I am testing on).  Both dtypes are fine with Mamba1, and I added this to skip fp32 tests for Mamba2 when GPUs are too old:

https://github.com/eric-czech/caduceus/blob/666c7b5c183457a04cb9d9f15c32bc3f64a19033/caduceus/tests/test_rcps.py#L99-L113

2. I was getting this same Mamba2 error: `causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8`, which was fairly easy to avoid by doing what was mentioned in https://github.com/state-spaces/mamba/issues/351#issuecomment-2167091940, i.e. make sure `d_model * expand / headdim` is a multiple of 8`:

https://github.com/eric-czech/caduceus/blob/666c7b5c183457a04cb9d9f15c32bc3f64a19033/caduceus/tests/test_rcps.py#L77-L91

Now all the tests clear with both versions of Mamba.  I'll also note that since I was doubling the number of tests by testing both Mamba versions, I cut down the number of batch dim values tested for some tests (i.e. from `[2, 4]` to `[2]`).